### PR TITLE
fix: Resolve button interaction bug caused by side menu

### DIFF
--- a/script.js
+++ b/script.js
@@ -32,10 +32,12 @@ userInput.addEventListener('keydown', (event) => {
 // Toggle side menu
 menuBtn.addEventListener('click', () => {
     sideMenu.style.width = '250px';
+    sideMenu.classList.add('side-menu-open');
 });
 
 closeBtn.addEventListener('click', () => {
     sideMenu.style.width = '0';
+    sideMenu.classList.remove('side-menu-open');
 });
 
 // Toggle dark mode

--- a/styles.css
+++ b/styles.css
@@ -174,6 +174,11 @@ body.dark-mode #user-input {
     transition: 0.5s;
     padding-top: 60px;
     color: white;
+    pointer-events: none;
+}
+
+.side-menu.side-menu-open {
+    pointer-events: auto;
 }
 
 .side-menu a {


### PR DESCRIPTION
This commit fixes a bug where buttons on the main chat interface were not clickable. The issue was caused by the side menu element, which was overlaying the entire screen and capturing all mouse events, even when it was visually hidden.

The fix involves using the `pointer-events` CSS property to control when the side menu can receive mouse events. By default, the side menu now has `pointer-events: none`, allowing clicks to pass through to the elements behind it. When the menu is opened, the `pointer-events` property is set to `auto`, allowing interaction with the menu itself.