### PR TITLE
feat: Implement detailed TTS settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,17 +29,38 @@
                 <select id="model-select"></select>
             </div>
 
-            <div class="setting">
-                <label for="tts-toggle">Enable TTS:</label>
-                <input type="checkbox" id="tts-toggle">
-            </div>
-
-            <div class="setting">
-                <label for="tts-voice-select">TTS Voice:</label>
-                <select id="tts-voice-select"></select>
-            </div>
-
             <button id="apply-btn">Apply</button>
+
+            <hr>
+
+            <h2>TTS Setting</h2>
+
+            <div class="setting">
+                <label for="browser-tts-toggle">Enable Browser TTS:</label>
+                <input type="checkbox" id="browser-tts-toggle">
+            </div>
+
+            <div class="setting">
+                <label for="browser-tts-volume">Volume:</label>
+                <input type="range" id="browser-tts-volume" min="0" max="100" value="50">
+            </div>
+
+            <h3>AI TTS Setting</h3>
+
+            <div class="setting">
+                <label for="ai-tts-toggle">Enable AI TTS:</label>
+                <input type="checkbox" id="ai-tts-toggle">
+            </div>
+
+            <div class="setting">
+                <label for="ai-tts-model-select">AI Model:</label>
+                <select id="ai-tts-model-select"></select>
+            </div>
+
+            <div class="setting">
+                <label for="ai-tts-voice-select">AI Voice:</label>
+                <select id="ai-tts-voice-select"></select>
+            </div>
 
             <hr>
 

--- a/styles.css
+++ b/styles.css
@@ -252,8 +252,8 @@ body.dark-mode #user-input {
     }
 }
 
-/* TTS Toggle Switch */
-#tts-toggle {
+/* TTS Toggle Switches */
+#browser-tts-toggle, #ai-tts-toggle {
     appearance: none;
     width: 3em;
     height: 1.5em;
@@ -264,7 +264,7 @@ body.dark-mode #user-input {
     transition: background-color 0.3s;
 }
 
-#tts-toggle::before {
+#browser-tts-toggle::before, #ai-tts-toggle::before {
     content: '';
     width: 1.2em;
     height: 1.2em;
@@ -276,15 +276,28 @@ body.dark-mode #user-input {
     transition: transform 0.3s;
 }
 
-#tts-toggle:checked {
+#browser-tts-toggle:checked, #ai-tts-toggle:checked {
     background-color: #5a9;
 }
 
-#tts-toggle:checked::before {
+#browser-tts-toggle:checked::before, #ai-tts-toggle:checked::before {
     transform: translateX(1.5em);
 }
 
-#tts-voice-select:disabled {
+/* Volume Slider */
+#browser-tts-volume {
+    width: calc(100% - 30px);
+}
+
+/* AI TTS Settings */
+.side-menu h3 {
+    padding: 10px 15px;
+    margin-top: 10px;
+    border-top: 1px solid #555;
+}
+
+#ai-tts-model-select:disabled,
+#ai-tts-voice-select:disabled {
     opacity: 0.5;
     cursor: not-allowed;
 }


### PR DESCRIPTION
This commit introduces a comprehensive Text-to-Speech (TTS) settings panel, allowing you to choose between the browser's built-in TTS and Groq's AI-powered TTS.

The following features have been added:
- A new "TTS Setting" section in the side menu.
- A toggle to enable/disable the browser's TTS.
- A volume slider for the browser's TTS.
- An "AI TTS Setting" subsection.
- A dropdown to select the AI TTS model (`playai-tts` or `playai-tts-arabic`).
- A toggle to enable/disable the AI TTS.
- A dropdown to select the voice for the chosen AI TTS model.

The `speak()` function has been updated to handle both TTS methods, providing a flexible and powerful TTS experience.