### PR TITLE
feat: Separate browser and AI TTS voice dropdowns

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,11 @@
                 <input type="range" id="browser-tts-volume" min="0" max="100" value="50">
             </div>
 
+            <div class="setting">
+                <label for="browser-tts-voice-select">No AI Voice:</label>
+                <select id="browser-tts-voice-select"></select>
+            </div>
+
             <h3>AI TTS Setting</h3>
 
             <div class="setting">

--- a/script.js
+++ b/script.js
@@ -17,6 +17,7 @@ const browserTtsVolume = document.getElementById('browser-tts-volume');
 const aiTtsToggle = document.getElementById('ai-tts-toggle');
 const aiTtsModelSelect = document.getElementById('ai-tts-model-select');
 const aiTtsVoiceSelect = document.getElementById('ai-tts-voice-select');
+const browserTtsVoiceSelect = document.getElementById('browser-tts-voice-select');
 
 // Gloabl variables
 let conversationHistory = [];
@@ -58,10 +59,23 @@ function populateAiTtsVoices() {
     });
 }
 
+function populateBrowserTtsVoices() {
+    const voices = speechSynthesis.getVoices();
+    browserTtsVoiceSelect.innerHTML = '';
+    voices.forEach(voice => {
+        const option = document.createElement('option');
+        option.value = voice.name;
+        option.textContent = `${voice.name} (${voice.lang})`;
+        browserTtsVoiceSelect.appendChild(option);
+    });
+}
+
 // 2. EVENT LISTENERS
 
 browserTtsToggle.addEventListener('click', () => {
     browserTtsEnabled = browserTtsToggle.checked;
+    browserTtsVolume.disabled = !browserTtsEnabled;
+    browserTtsVoiceSelect.disabled = !browserTtsEnabled;
 });
 
 aiTtsToggle.addEventListener('click', () => {
@@ -349,6 +363,10 @@ if (SpeechRecognition) {
 async function speak(text) {
     if (browserTtsEnabled) {
         const utterance = new SpeechSynthesisUtterance(text);
+        const selectedVoice = speechSynthesis.getVoices().find(voice => voice.name === browserTtsVoiceSelect.value);
+        if (selectedVoice) {
+            utterance.voice = selectedVoice;
+        }
         utterance.volume = browserTtsVolume.value / 100;
         utterance.onend = () => {
             if (isVoiceMode) {
@@ -413,5 +431,9 @@ document.addEventListener('DOMContentLoaded', () => {
     populateAiTtsVoices();
     aiTtsModelSelect.disabled = true;
     aiTtsVoiceSelect.disabled = true;
+
+    speechSynthesis.onvoiceschanged = populateBrowserTtsVoices;
+    browserTtsVoiceSelect.disabled = true;
+
     initializeApp();
 });


### PR DESCRIPTION
This commit refactors the Text-to-Speech (TTS) settings to provide a clearer distinction between the browser's native TTS and Groq's AI-powered TTS.

The following changes have been made:
- The TTS voices are now separated into two distinct dropdown menus: "No AI Voice" for the browser's voices and "AI Voice" for Groq's voices.
- The `script.js` has been updated to populate both dropdowns accordingly.
- The `speak()` function now uses the appropriate voice from the correct dropdown based on which TTS method is enabled.

This change improves the user experience by making it more intuitive to select a voice and by preventing accidental usage of the AI TTS.