### PR TITLE
feat: Filter conversational models and set default

### DIFF
--- a/script.js
+++ b/script.js
@@ -254,6 +254,16 @@ function appendMessage(message, sender) {
  * Fetches and displays available models from the Groq API.
  * @param {string} apiKey - The Groq API key.
  */
+const conversationalModels = [
+    "gemma-7b-it",
+    "llama3-8b-8192",
+    "llama-guard-3-8b",
+    "mixtral-8x7b-32768",
+    "llama3-70b-8192",
+    "deepseek-r1-distill-llama-70b",
+    "llama-3.3-70b-versatile"
+];
+
 async function fetchAndDisplayModels(apiKey) {
     try {
         const response = await fetch('https://api.groq.com/openai/v1/models', {
@@ -271,10 +281,15 @@ async function fetchAndDisplayModels(apiKey) {
         const data = await response.json();
         modelSelect.innerHTML = '';
         data.data.forEach(model => {
-            const option = document.createElement('option');
-            option.value = model.id;
-            option.textContent = model.id;
-            modelSelect.appendChild(option);
+            if (conversationalModels.includes(model.id)) {
+                const option = document.createElement('option');
+                option.value = model.id;
+                option.textContent = model.id;
+                if (model.id === 'gemma-7b-it') {
+                    option.selected = true;
+                }
+                modelSelect.appendChild(option);
+            }
         });
     } catch (error) {
         console.error('Error fetching models:', error);


### PR DESCRIPTION
This commit updates the model selection dropdown to only display a curated list of conversational models. This simplifies the user experience and ensures that only the most suitable models are used.

The following changes have been made:
- A list of conversational models has been added to `script.js`.
- The `fetchAndDisplayModels` function has been updated to filter the models returned from the Groq API based on this list.
- "gemma-7b-it" is now the default selected model after applying the API key.