### PR TITLE
Fix: Side menu not clickable after being opened

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,11 +31,11 @@ userInput.addEventListener('keydown', (event) => {
 
 // Toggle side menu
 menuBtn.addEventListener('click', () => {
-    sideMenu.style.width = '250px';
+    sideMenu.classList.add('side-menu-open');
 });
 
 closeBtn.addEventListener('click', () => {
-    sideMenu.style.width = '0';
+    sideMenu.classList.remove('side-menu-open');
 });
 
 // Toggle dark mode

--- a/styles.css
+++ b/styles.css
@@ -178,6 +178,7 @@ body.dark-mode #user-input {
 }
 
 .side-menu.side-menu-open {
+    width: 250px;
     pointer-events: auto;
 }
 


### PR DESCRIPTION
The side menu was previously unclickable because the 'side-menu-open' class, which enables pointer events, was not being added when the menu was opened. This change updates the JavaScript to correctly toggle this class and modifies the CSS to ensure the menu's width is also controlled by this class. This makes the menu and its contents fully interactive when open.