### PR TITLE
feat: Update voice models and Deepgram API params

### DIFF
--- a/script.js
+++ b/script.js
@@ -139,9 +139,7 @@ function updateDeepgramApiStatus(isValid) {
 
 function populateDeepgramVoices() {
     const deepgramVoices = [
-        "aura-asteria-en", "aura-luna-en", "aura-stella-en", "aura-athena-en",
-        "aura-hera-en", "aura-orion-en", "aura-arcas-en", "aura-perseus-en",
-        "aura-angus-en", "aura-orpheus-en", "aura-helios-en", "aura-zeus-en"
+        "aura-athena-en", "aura-orion-en"
     ];
 
     deepgramVoiceSelect.innerHTML = '';
@@ -173,10 +171,7 @@ speechSynthesis.onvoiceschanged = populateBrowserTtsVoices;
 
 const groqTtsVoices = {
     'playai-tts': [
-        'Arista-PlayAI', 'Atlas-PlayAI', 'Basil-PlayAI', 'Briggs-PlayAI', 'Calum-PlayAI',
-        'Celeste-PlayAI', 'Cheyenne-PlayAI', 'Chip-PlayAI', 'Cillian-PlayAI', 'Deedee-PlayAI',
-        'Fritz-PlayAI', 'Gail-PlayAI', 'Indigo-PlayAI', 'Mamaw-PlayAI', 'Mason-PlayAI',
-        'Mikail-PlayAI', 'Mitch-PlayAI', 'Quinn-PlayAI', 'Thunder-PlayAI'
+        'Eleanor-PlayAI', 'Fritz-PlayAI'
     ],
     'playai-tts-arabic': [
         'Ahmad-PlayAI', 'Amira-PlayAI', 'Khalid-PlayAI', 'Nasser-PlayAI'
@@ -569,7 +564,7 @@ async function speak(text) {
             }
 
             try {
-                const response = await fetch(`https://api.deepgram.com/v1/speak?model=${voice}`, {
+                const response = await fetch(`https://api.deepgram.com/v1/speak?model=${voice}&smart_format=true&utterances=true&punctuation=true`, {
                     method: 'POST',
                     headers: {
                         'Authorization': `Token ${apiKey}`,


### PR DESCRIPTION
- Limit Deepgram voice models to Athena and Orion.
- Limit Groq voice models to Eleanor and Fritz.
- Add smart_format, utterances, and punctuation parameters to the Deepgram API call to handle filler words, utterances, and punctuations.