### PR TITLE
Fix(html): Add missing elements for call UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,7 @@
 
     <div id="call-ui-overlay" class="call-ui-overlay hidden">
         <div class="call-top-bar">
+            <span id="mic-status" class="status-dot"></span>
             <span class="top-bar-title">Voice Chat Active</span>
             <span id="call-timer">00:00</span>
             <div class="top-bar-buttons">
@@ -128,6 +129,7 @@
 
         <div class="call-center-stage">
             <div id="ai-avatar" class="avatar"></div>
+            <div id="call-status-text"></div>
             <canvas id="waveform-canvas" width="500" height="100"></canvas>
         </div>
 


### PR DESCRIPTION
Adds the `call-status-text` and `mic-status` elements to `index.html`.

These elements are referenced in `script.js` to display the status of the voice call, but they were missing from the HTML markup. This caused a "Cannot set properties of null" error when initiating a call, preventing the feature from working.

This change ensures the elements exist, allowing the script to update the call status and indicator correctly.